### PR TITLE
Don't iterate to check equality if vector sizes are different.

### DIFF
--- a/CheckUtils.h
+++ b/CheckUtils.h
@@ -41,6 +41,9 @@ bool equal(const T& expected, const T& actual,
 template<class T, class Predicate = std::function<bool(const T&, const T&)>>
 bool orderedSame(const vector<T> &v1, const vector<T> &v2,
                  Predicate predicate) {
+    if (v1.size() != v2.size())
+        return false;
+
     unsigned long size = v1.size();
 
 


### PR DESCRIPTION
Main reason to do so is because I was getting segfault for the initial
API.h and a more complete ref_file.txt, as API returns an empty array.
